### PR TITLE
Array Copy

### DIFF
--- a/Java/DataType/ReferenceType/Array/ArrayCopy/ArrayCopyClone.java
+++ b/Java/DataType/ReferenceType/Array/ArrayCopy/ArrayCopyClone.java
@@ -1,0 +1,15 @@
+package test;
+
+import java.util.Arrays;
+
+public class Example {
+	public static void main(String[] args) {
+		int[] sourceArray = {1, 2, 3};
+		
+		int[] targetArray = sourceArray.clone();
+		
+		for (int value : targetArray) {
+			System.out.print(value + " ");
+		}
+	}
+}

--- a/Java/DataType/ReferenceType/Array/ArrayCopy/ArrayCopyFor.java
+++ b/Java/DataType/ReferenceType/Array/ArrayCopy/ArrayCopyFor.java
@@ -1,0 +1,16 @@
+package test;
+
+public class Example {
+	public static void main(String[] args) {
+		int[] sourceArray = {1, 2, 3};
+		int[] targetArray = new int[sourceArray.length];
+		
+		for (int i = 0; i < sourceArray.length; i++) {
+			targetArray[i] = sourceArray[i];
+		}
+		
+		for (int value : targetArray) {
+			System.out.print(value + " ");
+		}
+	}
+}

--- a/Java/DataType/ReferenceType/Array/ArrayCopy/ArrayCopyOf.java
+++ b/Java/DataType/ReferenceType/Array/ArrayCopy/ArrayCopyOf.java
@@ -1,0 +1,15 @@
+package test;
+
+import java.util.Arrays;
+
+public class Example {
+	public static void main(String[] args) {
+		int[] sourceArray = {1, 2, 3};
+		
+		int[] targetArray = Arrays.copyOf(sourceArray, sourceArray.length);
+		
+		for (int value : targetArray) {
+			System.out.print(value + " ");
+		}
+	}
+}

--- a/Java/DataType/ReferenceType/Array/ArrayCopy/README.md
+++ b/Java/DataType/ReferenceType/Array/ArrayCopy/README.md
@@ -1,0 +1,29 @@
+#### Array Copy
+
+자바에서 배열의 복사에는 다양한 방법이 있습니다. 배열이 참조 타입인 경우, 얕은 복사(shallow copy)가 됩니다. 원본 배열과 복사본 배열이 같은 객체를 참조하게 됩니다. 배열의 내부 객체가 변경되면 원본과 복사본 모두 영향을 받게 됩니다.
+
+1. for 루프로 배열 요소 복사
+
+```
+for (int i = 0; i < sourceArray.length; i++) {
+	targetArray[i] = sourceArray[i];
+}
+```
+
+2. System.arraycopy() 메서드 사용
+
+```
+System.arraycopy(sourceArray, 0, targetArray, 0, sourceArray.length);
+```
+
+3. Arrays.copyOf() 메서드 사용
+
+```
+int[] targetArray = Arrays.copyOf(sourceArray, sourceArray.length);
+```
+
+4. clone() 메서드 사용
+
+```
+int[] targetArray = sourceArray.clone();
+```

--- a/Java/DataType/ReferenceType/Array/ArrayCopy/SystemArrayCopy.java
+++ b/Java/DataType/ReferenceType/Array/ArrayCopy/SystemArrayCopy.java
@@ -1,0 +1,14 @@
+package test;
+
+public class Example {
+	public static void main(String[] args) {
+		int[] sourceArray = {1, 2, 3};
+		int[] targetArray = new int[sourceArray.length];
+		
+		System.arraycopy(sourceArray, 0, targetArray, 0, sourceArray.length);
+		
+		for (int value : targetArray) {
+			System.out.print(value + " ");
+		}
+	}
+}


### PR DESCRIPTION
Array Copy

자바에서 배열의 복사에는 다양한 방법이 있습니다. 배열이 참조 타입인 경우, 얕은 복사(shallow copy)가 됩니다. 원본 배열과 복사본 배열이 같은 객체를 참조하게 됩니다. 배열의 내부 객체가 변경되면 원본과 복사본 모두 영향을 받게 됩니다.

1. for 루프로 배열 요소 복사
2. System.arraycopy() 메서드 사용
3. Arrays.copyOf() 메서드 사용
4. clone() 메서드 사용